### PR TITLE
fix type error

### DIFF
--- a/delineate.py
+++ b/delineate.py
@@ -379,6 +379,10 @@ def delineate():
     # Iterate over the basins so that we only have
     # to open up each Level 2 Basin shapefile once, and handle all of the gages in it
     for basin in basins:
+        # mmaelicke: I am not why this happens or where this comes from, but for some 
+        # of my inputs ie. on megabasin 11 or 12, basin in a float. Then, load_gdf does not work.
+        basin = int(basin)
+        
         # Create a dataframe of the gages_basins_join in that basins
         gages_in_basin = gages_basins_join[gages_basins_join["BASIN"] == basin]
         num_gages_in_basin = len(gages_in_basin)


### PR DESCRIPTION
Hi,
me again. I ran into a strange error, when trying to delineate from megabasins 11 or 12. 

https://github.com/mheberger/delineator/blob/1fe84cb2a309e6817baae407f2d93a6e27a56736/delineate.py#L381

the for loop over the basins suddenly changes to floats, which makes `load_gdf` fail:

https://github.com/mheberger/delineator/blob/1fe84cb2a309e6817baae407f2d93a6e27a56736/delineate.py#L388

here, I add a quick fix to force the `basin`back to integer. However, I do not fully understand why this happens in the first place. From my understanding of the code, the content of `basins` is not influenced by me, when I change the input outlets. 
The only two explanations for me are: nobody tried these to megabasins so far, which is unlikely. The other option is that geopandas is causing the problem. I had to upgrade to geopandas version 1.0.1, as the <= 14.2 versions had problems with pygeos, that I could not solve otherwise.

I still think this needs some investigation, what exactly is happening. Maybe you have yet another idea.
